### PR TITLE
Tools: added missing opts values

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -83,11 +83,11 @@ var pronunciation = module.exports.pronunciation = function(data) {
 			log.verbose("CMU doesn't know how to pronounce " + d.name);
 		}
 	});
-	log.info("(Found pronunciations for " + data.filter(function(d) { return d.stressed; }).length + " of those.)");		
+	log.info("(Found pronunciations for " + data.filter(function(d) { return d.stressed; }).length + " of those.)");
 }
 
 // make an individual name dense
-var densify = module.exports.densify = function(datum) {
+var densify = module.exports.densify = function(datum, opts) {
 	for (var year = opts.start; year <= opts.end; year += 1) {
 		if (typeof datum[year] == "undefined") {
 			datum[year] = 0;
@@ -96,10 +96,10 @@ var densify = module.exports.densify = function(datum) {
 	}
 }
 
-module.exports.dense = function(data, opts) { 
+module.exports.dense = function(data, opts) {
 	// fill in zero for names not present in given year if desired
 	data.forEach(function(d) {
-		densify(d);
+		densify(d['values'], opts);
 	});
 }
 
@@ -119,7 +119,7 @@ function maxima(name, opts) {
 		for (var i = Math.max(opts.start, year - window_size); i <= Math.min(opts.end, year + window_size); i += 1) {
 			if (typeof name.percents[i] == "undefined" || typeof name.percents[year] == "undefined") {
 				isMaxima = false;
-				break;				
+				break;
 			}
 			if ((i < year && name.percents[i] > name.percents[year]) || (i > year && name.percents[i] > name.percents[year])) {
 				isMaxima = false;


### PR DESCRIPTION
Fix for using `dense` format with start/end dates

```
➜  babynames git:(master) ✗ ./index.js store --format=json --start=1920 --min=20 --normalize --peaks --maxima --dense
info Aggregating data
#################################################################################################### 100%
info Found a total of 106816 names between 1920 and 2017
info Reduced to 26964 names that peak at at least 20 instances.
/Users/bryanlatten/repos/babynames/lib/tools.js:91
  for (var year = opts.start; year <= opts.end; year += 1) {
                  ^

ReferenceError: opts is not defined
    at module.exports.densify (/Users/bryanlatten/repos/babynames/lib/tools.js:91:18)
```
